### PR TITLE
Upgrade to latest UAA identity scim API 2.4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,11 @@ targetCompatibility = 1.7
 
 repositories {
 	mavenCentral()
-    maven { url "http://repo.spring.io/libs-release-local" }
+	maven { url "http://repo.spring.io/libs-release-local" }
 }
 dependencies {
-    compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version:'2.0.4.RELEASE'
-	compile group: 'org.cloudfoundry.identity', name: 'cloudfoundry-identity-scim', version: '2.1.0'
-    testCompile group: 'junit', name: 'junit', version:'4.12'
+	compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version:'2.0.7.RELEASE'
+	compile group: 'org.cloudfoundry.identity', name: 'cloudfoundry-identity-scim', version: '2.4.0'
+	
+	testCompile group: 'junit', name: 'junit', version:'4.12'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,9 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.4.RELEASE</version>
+			<version>2.0.7.RELEASE</version>
 		</dependency>
+		
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -25,7 +26,7 @@
 		<dependency>
 			<groupId>org.cloudfoundry.identity</groupId>
 			<artifactId>cloudfoundry-identity-scim</artifactId>
-			<version>2.1.0</version>
+			<version>2.4.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/org/cloudfoundry/identity/uaa/api/client/impl/UaaClientOperationsImpl.java
+++ b/src/main/java/org/cloudfoundry/identity/uaa/api/client/impl/UaaClientOperationsImpl.java
@@ -16,6 +16,8 @@ package org.cloudfoundry.identity.uaa.api.client.impl;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.identity.uaa.api.client.UaaClientOperations;
 import org.cloudfoundry.identity.uaa.api.common.impl.UaaConnectionHelper;
 import org.cloudfoundry.identity.uaa.api.common.model.WrappedSearchResults;
@@ -28,18 +30,16 @@ import org.springframework.util.Assert;
 /**
  * @see UaaClientOperations
  * @author Josh Ghiloni
- *
  */
 public class UaaClientOperationsImpl implements UaaClientOperations {
 
-	private static final ParameterizedTypeReference<String> STRING_REF = new ParameterizedTypeReference<String>() {
-	};
+	private static final ParameterizedTypeReference<String> STRING_REF = new ParameterizedTypeReference<String>() {};
 
-	private static final ParameterizedTypeReference<BaseClientDetails> CLIENT_REF = new ParameterizedTypeReference<BaseClientDetails>() {
-	};
+	private static final ParameterizedTypeReference<BaseClientDetails> CLIENT_REF = new ParameterizedTypeReference<BaseClientDetails>() {};
 
-	private static final ParameterizedTypeReference<WrappedSearchResults<BaseClientDetails>> CLIENTS_REF = new ParameterizedTypeReference<WrappedSearchResults<BaseClientDetails>>() {
-	};
+	private static final ParameterizedTypeReference<WrappedSearchResults<BaseClientDetails>> CLIENTS_REF = new ParameterizedTypeReference<WrappedSearchResults<BaseClientDetails>>() {};
+
+	private static final Log log = LogFactory.getLog(UaaClientOperationsImpl.class);
 
 	private UaaConnectionHelper helper;
 
@@ -83,7 +83,9 @@ public class UaaClientOperationsImpl implements UaaClientOperations {
 		body.put("secret", newSecret);
 
 		String result = helper.put("/oauth/clients/{id}/secret", body, STRING_REF, clientId);
-		System.out.println(result);
+		if (log.isDebugEnabled()) {
+			log.debug(result);
+		}
 
 		return (result != null);
 	}

--- a/src/main/java/org/cloudfoundry/identity/uaa/api/user/UaaUserOperations.java
+++ b/src/main/java/org/cloudfoundry/identity/uaa/api/user/UaaUserOperations.java
@@ -39,7 +39,7 @@ public interface UaaUserOperations {
 	 * 
 	 * @param user the updated user
 	 * @return the user as returned from the UAA api
-	 * @see #changeUserPassword(String, String)
+	 * @see #changeUserPassword(String, String, String)
 	 */
 	public ScimUser updateUser(ScimUser user);
 
@@ -57,9 +57,10 @@ public interface UaaUserOperations {
 	 * <b>TODO</b>: Add a method to change the current user's password, if not in a client-credential-only scope
 	 * 
 	 * @param userId the user's id (not their username)
+	 * @param oldPassword the old password
 	 * @param newPassword the new password
 	 */
-	public void changeUserPassword(String userId, String newPassword);
+	public void changeUserPassword(String userId, String oldPassword, String newPassword);
 
 	/**
 	 * Looks up a user in the database by their name.

--- a/src/main/java/org/cloudfoundry/identity/uaa/api/user/impl/UaaUserOperationsImpl.java
+++ b/src/main/java/org/cloudfoundry/identity/uaa/api/user/impl/UaaUserOperationsImpl.java
@@ -13,9 +13,10 @@
  */
 package org.cloudfoundry.identity.uaa.api.user.impl;
 
-import static org.cloudfoundry.identity.uaa.scim.ScimCore.SCHEMAS;
+import static org.cloudfoundry.identity.uaa.scim.ScimCore.*;
 
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.cloudfoundry.identity.uaa.api.common.impl.UaaConnectionHelper;
 import org.cloudfoundry.identity.uaa.api.common.model.WrappedSearchResults;
@@ -32,6 +33,7 @@ import org.springframework.util.CollectionUtils;
  * @see UaaUserOperations
  * 
  * @author Josh Ghiloni
+ * @author Thomas Darimont
  *
  */
 public class UaaUserOperationsImpl implements UaaUserOperations {
@@ -78,11 +80,16 @@ public class UaaUserOperationsImpl implements UaaUserOperations {
 		helper.delete("/Users/{id}", STRING_REF, userId);
 	}
 
-	public void changeUserPassword(String userId, String newPassword) {
+	public void changeUserPassword(String userId, String oldPassword, String newPassword) {
 		Assert.hasText(userId);
+		Assert.hasText(oldPassword);
 		Assert.hasText(newPassword);
 
-		helper.put("/Users/{id}/password", Collections.singletonMap("password", newPassword), STRING_REF, userId);
+		Map<String, String> passwordChange = new HashMap<String, String>();
+		passwordChange.put("password", newPassword);
+		passwordChange.put("oldPassword", oldPassword);
+
+		helper.put("/Users/{id}/password", passwordChange, STRING_REF, userId);
 	}
 
 	public SearchResults<ScimUser> getUsers(FilterRequest request) {

--- a/src/test/java/org/cloudfoundry/identity/uaa/api/client/test/AbstractOperationTest.java
+++ b/src/test/java/org/cloudfoundry/identity/uaa/api/client/test/AbstractOperationTest.java
@@ -13,10 +13,6 @@
  */
 package org.cloudfoundry.identity.uaa.api.client.test;
 
-import static org.junit.Assume.assumeTrue;
-
-import java.io.IOException;
-import java.net.Socket;
 import java.net.URL;
 
 import org.cloudfoundry.identity.uaa.api.UaaConnectionFactory;
@@ -26,43 +22,27 @@ import org.springframework.security.oauth2.common.AuthenticationScheme;
 
 /**
  * @author Josh Ghiloni
- *
  */
 public abstract class AbstractOperationTest {
-	private static boolean uaaRunning;
 
-	private static UaaConnection connection;
+	private static final String UAA_BASE_URL = "http://localhost:8080/uaa";
 
-	protected static void init() throws Exception {
-		try {
-			Socket test = new Socket("localhost", 8080);
-			uaaRunning = true;
-			test.close();
-		}
-		catch (IOException e) {
-			System.err.println("UAA is not running, skip these tests");
-			uaaRunning = false;
-			return;
-		}
-		finally {
-			String baseUrl = "http://localhost:8080/uaa";
-			
-			ClientCredentialsResourceDetails credentials = new ClientCredentialsResourceDetails();
-			credentials.setAccessTokenUri(baseUrl + "/oauth/token");
-//			credentials.setAuthenticationScheme(AuthenticationScheme.header);
-			credentials.setClientAuthenticationScheme(AuthenticationScheme.header);
-			credentials.setClientId("admin");
-			credentials.setClientSecret("adminsecret");
-			
-			connection = UaaConnectionFactory.getConnection(new URL(baseUrl), credentials);
-		}
+	protected ClientCredentialsResourceDetails getDefaultClientCredentials() {
+
+		ClientCredentialsResourceDetails credentials = new ClientCredentialsResourceDetails();
+		credentials.setAccessTokenUri(UAA_BASE_URL + "/oauth/token");
+		credentials.setClientAuthenticationScheme(AuthenticationScheme.header);
+		credentials.setClientId("admin");
+		credentials.setClientSecret("adminsecret");
+
+		return credentials;
 	}
 
-	protected static void ignoreIfUaaNotRunning() {
-		assumeTrue(uaaRunning);
+	protected UaaConnection getConnection() throws Exception {
+		return getConnection(getDefaultClientCredentials());
 	}
 
-	protected static UaaConnection getConnection() {
-		return connection;
+	protected UaaConnection getConnection(ClientCredentialsResourceDetails clientCredentials) throws Exception {
+		return UaaConnectionFactory.getConnection(new URL(UAA_BASE_URL), clientCredentials);
 	}
 }

--- a/src/test/java/org/cloudfoundry/identity/uaa/api/client/test/UaaGroupOperationTest.java
+++ b/src/test/java/org/cloudfoundry/identity/uaa/api/client/test/UaaGroupOperationTest.java
@@ -13,9 +13,7 @@
  */
 package org.cloudfoundry.identity.uaa.api.client.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Collection;
 
@@ -24,7 +22,8 @@ import org.cloudfoundry.identity.uaa.api.group.UaaGroupOperations;
 import org.cloudfoundry.identity.uaa.rest.SearchResults;
 import org.cloudfoundry.identity.uaa.scim.ScimGroup;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupMember;
-import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 /**
@@ -32,18 +31,19 @@ import org.junit.Test;
  *
  */
 public class UaaGroupOperationTest extends AbstractOperationTest {
-	private static UaaGroupOperations operations;
+	
+	@ClassRule public static UaaServerAvailable uaaServerAvailable = new UaaServerAvailable();
+	
+	private UaaGroupOperations operations;
 
-	@BeforeClass
-	public static void setUp() throws Exception {
-		init();
-
+	@Before
+	public void setUp() throws Exception {
 		operations = getConnection().groupOperations();
 	}
 
 	@Test
 	public void testGroupRetrieval() {
-		ignoreIfUaaNotRunning();
+		
 		SearchResults<ScimGroup> groups = operations.getGroups(FilterRequestBuilder.showAll());
 
 		assertNotNull(groups);
@@ -56,7 +56,6 @@ public class UaaGroupOperationTest extends AbstractOperationTest {
 
 	@Test
 	public void testGroupCreateUpdateDelete() {
-		ignoreIfUaaNotRunning();
 		
 		String id = "marissa";
 

--- a/src/test/java/org/cloudfoundry/identity/uaa/api/client/test/UaaServerAvailable.java
+++ b/src/test/java/org/cloudfoundry/identity/uaa/api/client/test/UaaServerAvailable.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cloudfoundry.identity.uaa.api.client.test;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import org.junit.Assume;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * @author Thomas Darimont
+ */
+public class UaaServerAvailable implements TestRule {
+
+	private static final boolean UAA_RUNNING;
+
+	private static final String UAA_TEST_HOST = System.getProperty("test.uaa.server.hostname", "localhost");
+	private static final int UAA_TEST_PORT = Integer.getInteger("test.uaa.server.port", 8080);
+
+	static {
+
+		boolean serverAvailable = false;
+		try {
+			Socket test = new Socket(UAA_TEST_HOST, UAA_TEST_PORT);
+			serverAvailable = true;
+			test.close();
+		} catch (IOException e) {
+			System.err.println("UAA is not running, skip these tests");
+		}
+
+		UAA_RUNNING = serverAvailable;
+	}
+
+	private static final Statement NOT_AVAILABLE_STATEMEMT = new Statement() {
+		@Override
+		public void evaluate() throws Throwable {
+			Assume.assumeTrue(
+					String.format("Skipping test due to UAA not being available @: %s:%s", UAA_TEST_HOST, UAA_TEST_PORT), false);
+		}
+	};
+
+	@Override
+	public Statement apply(final Statement base, Description description) {
+		return UAA_RUNNING ? new Statement() {
+
+			@Override
+			public void evaluate() throws Throwable {
+				base.evaluate();
+			}
+		} : NOT_AVAILABLE_STATEMEMT;
+	}
+
+}


### PR DESCRIPTION
Upgradeed codebase to latest spring-security-oauth version 2.0.7.RELEASE and UAA 2.4 APIs.

Adapted changeUserPassword in UaaUserOperationsImpl to latest changes in UAA 2.4 API.
Revised test setup - instead of changing properties admin client we
create a dedicated test user to test property changes in order to make
the tests more robust. Previously the tests where dependend on
execution order and failed with Java 8.
Introduced UaaServerAvailable JUnit Rule to mark test cases that require UAA functionality. 

Adapted maven / gradle builds for dependency upgrades.

Note that one needs to add the "password.write" role to the authorities of the admin client to be able to change a users password via the admin client.
See: https://github.com/cloudfoundry/uaa/blob/786372e012e29ec51e5d16a3971b4c04ec2e7fe0/uaa/src/main/webapp/WEB-INF/spring/oauth-clients.xml#L58
